### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -18,7 +18,7 @@ fn merge_records(dst: &mut weather::Report, src: weather::Report) {
 }
 
 fn to_sorted_vec(hmap: weather::Report) -> Vec<weather::Station> {
-    let mut v = hmap.to_vec();
+    let mut v = hmap.into_vec();
     v.sort_unstable();
     v
 }

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -53,7 +53,7 @@ mod tests {
 
     fn check(input: &str, expected: Vec<weather::Station>) {
         let map = calculate(input.as_bytes());
-        let mut actual: Vec<weather::Station> = map.to_vec();
+        let mut actual: Vec<weather::Station> = map.into_vec();
         actual.sort_unstable();
         assert_eq!(actual, expected);
     }

--- a/src/pre_processing.rs
+++ b/src/pre_processing.rs
@@ -29,7 +29,7 @@ impl<'a> Splitter<'a> {
     fn partition(mut self) -> Partition {
         let mut chunks = Vec::new();
         let mut offset = 0;
-        while self.bytes.len() > 0 {
+        while !self.bytes.is_empty() {
             let end = self.get_chunk_end();
             chunks.push(offset..offset + end);
             self.bytes = &self.bytes[end..];

--- a/src/weather.rs
+++ b/src/weather.rs
@@ -6,6 +6,7 @@ pub use key::Key;
 pub use station::Station;
 use std::collections::hash_map::{Entry, IntoIter};
 
+#[derive(Default)]
 pub struct Report(FxHashMap<Key, Station>);
 
 impl Report {
@@ -25,13 +26,7 @@ impl Report {
         self.0.entry(k)
     }
 
-    pub fn to_vec(self) -> Vec<Station> {
+    pub fn into_vec(self) -> Vec<Station> {
         self.0.into_values().collect()
-    }
-}
-
-impl Default for Report {
-    fn default() -> Self {
-        Self(FxHashMap::default())
     }
 }

--- a/src/weather/station.rs
+++ b/src/weather/station.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Default, PartialEq, Eq, Ord)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct Station {
     pub name: String,
     min: i32,
@@ -47,7 +47,13 @@ impl Station {
 
 impl PartialOrd for Station {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.name.partial_cmp(&other.name)
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Station {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.name.cmp(&other.name)
     }
 }
 


### PR DESCRIPTION
- Clippy: Fix wrong_name_convetion for Report; derive Default for Station
- Fix clippy::non_canonical_partial_ord_impl for type Station
- Fix clippy::len_without_is_empty
