### PR TITLE
Tweak hash

### DIFF
--- a/src/weather/key.rs
+++ b/src/weather/key.rs
@@ -8,8 +8,18 @@ impl Key {
         // djb2 hash fn
         // hash(0) = 5381
         // hash(i) = hash(i-1) * 33 ^ byte[i]
-        let hash_fn = |hash, byte: &u8| (hash * 33) ^ u64::from(*byte);
-        Self(bytes.iter().fold(5381, hash_fn))
+        let hash_fn = |hash: u64, &byte| hash.wrapping_mul(33) + byte as u64;
+
+        let len = bytes.len();
+        let first = &bytes[..len.min(8)];
+        let last = if len > 8 { &bytes[len - 8..] } else { &[] };
+        Self(
+            first
+                .iter()
+                .chain(last)
+                .fold(5381, hash_fn)
+                .wrapping_mul(len as u64), // multiply with the length of input to ensure collisions free
+        )
     }
 }
 

--- a/src/weather/key.rs
+++ b/src/weather/key.rs
@@ -8,7 +8,7 @@ impl Key {
         // djb2 hash fn
         // hash(0) = 5381
         // hash(i) = hash(i-1) * 33 + byte[i]
-        let hash_fn = |hash: u64, &byte| hash.wrapping_mul(33) + byte as u64;
+        let hash_fn = |hash: u64, &byte| hash.wrapping_mul(33).wrapping_add(byte as u64);
 
         let len = bytes.len();
         let first = &bytes[..len.min(8)];

--- a/src/weather/key.rs
+++ b/src/weather/key.rs
@@ -18,7 +18,7 @@ impl Key {
                 .iter()
                 .chain(last)
                 .fold(5381, hash_fn)
-                .wrapping_mul(len as u64), // multiply with the length of input to ensure collisions free
+                .wrapping_mul(len as u64), // multiply with the length of input to ensure no collisions
         )
     }
 }

--- a/src/weather/key.rs
+++ b/src/weather/key.rs
@@ -7,7 +7,7 @@ impl Key {
     pub fn new(bytes: &[u8]) -> Self {
         // djb2 hash fn
         // hash(0) = 5381
-        // hash(i) = hash(i-1) * 33 ^ byte[i]
+        // hash(i) = hash(i-1) * 33 + byte[i]
         let hash_fn = |hash: u64, &byte| hash.wrapping_mul(33) + byte as u64;
 
         let len = bytes.len();


### PR DESCRIPTION
A crude analysis of our set of city names showed that we get a single hash collision if we use `djb2`-xor to hash the first and last 8 bytes. One way to ensure we get a collision free hash fn when restricting the amount of bytes like this is to in addition 
* multiply with the length of the input at the end
* switch to the original `djb2` that uses + instead of XOR.